### PR TITLE
Added the ability to specify a callback for customizing the grid setup

### DIFF
--- a/lib/js/ab-compensation-tools.js
+++ b/lib/js/ab-compensation-tools.js
@@ -284,143 +284,167 @@ var abCompToolkit = (function() {
         sizeFixSheet.insertRule('.jsgrid-table { width: 100%; }', 0);
         sizeFixSheet.insertRule('.grid-body { overflow: hidden; }', 0);
         
-        
-        theJsGrid = $("#grid").jsGrid({
-            fields: [{
-                name: "PublicSectorBody",
-                title: "Public Sector Body",
-                type: "text",
-                width: "auto",
-                sorter: "string",
-                headerTemplate: function () {
-                    return headerInnerHtml(this);
-                },
-                filtercss: "filter-form PublicSectorBody-filter",
-                headercss: strHeaderCss,
-            }, {
-                name: "Name",
-                title: "Name",
-                type: "text",
-                width: "auto",
-                headerTemplate: function () {
-                    return headerInnerHtml(this);
-                },
-                filtercss: "filter-form Name-filter",
-                headercss: strHeaderCss,
-            }, {
-                name: "Position",
-                title: "Position",
-                type: "text",
-                width: "auto",
-                headerTemplate: function () {
-                    return headerInnerHtml(this);
-                },
-                filtercss: "filter-form Position-filter",
-                headercss: strHeaderCss,
-            }, {
-                name: "Year",
-                title: "Year",
-                type: "number",
-                width: "6.6%",
-                headerTemplate: function () {
-                    return headerInnerHtml(this);
-                },
-                filtercss: "filter-form Year-filter",
-                headercss: strHeaderCss,
-            }, {
-                name: "Compensation",
-                title: "Compensation",
-                tooltip: "Compensation: Income plus taxable benefits paid to a member or employee. Excludes severance.",
-                type: "number",
-                width: "12.6%",
-                cellRenderer: function (value, item) {
-                    return "<td>" + renderDollarAmount(item["Compensation"]) + "</td>";
-                },
-                headerTemplate: function () {
-                    return headerInnerHtml(this);
-                },
-                filterTemplate: function () {
-                    return _filterTemplate_Numeric(this);
-                },
-                filterValue: function () {
-                    return _getNumericFilterValue(this);
-                },
-                filtercss: "filter-form Compensation-filter",
-                headercss: strHeaderCss,
-            }, {
-                name: "Other",
-                title: "Other",
-                tooltip: "Other: Non-taxable benefits, incudes public sector body’s share of pension and other contributions.",
-                type: "number",
-                width: "9.7%",
-                cellRenderer: function (value, item) {
-                    return "<td>" + renderDollarAmount(item["Other"]) + "</td>";
-                },
-                headerTemplate: function () {
-                    return headerInnerHtml(this);
-                },
-                filterTemplate: function () {
-                    return _filterTemplate_Numeric(this);
-                },
-                filterValue: function () {
-                    return _getNumericFilterValue(this);
-                },
-                filtercss: "filter-form Other-filter",
-                headercss: strHeaderCss,
-            }, {
-                name: "Severance",
-                title: "Severance",
-                tooltip: "Severance: Includes payments when employment or member’s appointment ends or retiring allowance.",
-                type: "number",
-                width: "11%",
-                cellRenderer: function (value, item) {
-                    return "<td>" + renderDollarAmount(item["Severance"]) + "</td>";
-                },
-                headerTemplate: function () {
-                    return headerInnerHtml(this);
-                },
-                filterTemplate: function () {
-                    return _filterTemplate_Numeric(this);
-                },
-                filterValue: function () {
-                    return _getNumericFilterValue(this);
-                },
-                filtercss: "filter-form Severance-filter",
-                headercss: strHeaderCss,
-            }, {
-                name: "Attachments",
-                title: "Attachments",
-                tooltip: "Attachments: An employment contract (C) or severance agreement (S) for certain designated employees or members. If neither document is applicable, no attachment is posted.",
-                type: "text",
-                width: "9%",
-                filtering: false,
-                sorting: false,
-                cellRenderer: function (value, item) {
-                    return "<td>" + renderAttachments(item["ContractAttachment"], item["TerminationAttachment"]) + "</td>";
-                },
-                headerTemplate: function () {
-                    return headerInnerHtml(this);
-                },
-                headercss: strHeaderCss,
-                filtercss: "filter-form",
-            }],
-            autoload: true,
-            controller: {
-                loadData: function (filter) {
+        var gridConfig = {
+            fields : [
+                    {
+                        name : "PublicSectorBody",
+                        title : "Public Sector Body",
+                        type : "text",
+                        width : "auto",
+                        sorter : "string",
+                        headerTemplate : function() {
+                            return headerInnerHtml(this);
+                        },
+                        filtercss : "filter-form PublicSectorBody-filter",
+                        headercss : strHeaderCss,
+                    },
+                    {
+                        name : "Name",
+                        title : "Name",
+                        type : "text",
+                        width : "auto",
+                        headerTemplate : function() {
+                            return headerInnerHtml(this);
+                        },
+                        filtercss : "filter-form Name-filter",
+                        headercss : strHeaderCss,
+                    },
+                    {
+                        name : "Position",
+                        title : "Position",
+                        type : "text",
+                        width : "auto",
+                        headerTemplate : function() {
+                            return headerInnerHtml(this);
+                        },
+                        filtercss : "filter-form Position-filter",
+                        headercss : strHeaderCss,
+                    },
+                    {
+                        name : "Year",
+                        title : "Year",
+                        type : "number",
+                        width : "6.6%",
+                        headerTemplate : function() {
+                            return headerInnerHtml(this);
+                        },
+                        filtercss : "filter-form Year-filter",
+                        headercss : strHeaderCss,
+                    },
+                    {
+                        name : "Compensation",
+                        title : "Compensation",
+                        tooltip : "Compensation: Income plus taxable benefits paid to a member or employee. Excludes severance.",
+                        type : "number",
+                        width : "12.6%",
+                        cellRenderer : function(value, item) {
+                            return "<td>"
+                                    + renderDollarAmount(item["Compensation"])
+                                    + "</td>";
+                        },
+                        headerTemplate : function() {
+                            return headerInnerHtml(this);
+                        },
+                        filterTemplate : function() {
+                            return _filterTemplate_Numeric(this);
+                        },
+                        filterValue : function() {
+                            return _getNumericFilterValue(this);
+                        },
+                        filtercss : "filter-form Compensation-filter",
+                        headercss : strHeaderCss,
+                    },
+                    {
+                        name : "Other",
+                        title : "Other",
+                        tooltip : "Other: Non-taxable benefits, incudes public sector body’s share of pension and other contributions.",
+                        type : "number",
+                        width : "9.7%",
+                        cellRenderer : function(value, item) {
+                            return "<td>" + renderDollarAmount(item["Other"])
+                                    + "</td>";
+                        },
+                        headerTemplate : function() {
+                            return headerInnerHtml(this);
+                        },
+                        filterTemplate : function() {
+                            return _filterTemplate_Numeric(this);
+                        },
+                        filterValue : function() {
+                            return _getNumericFilterValue(this);
+                        },
+                        filtercss : "filter-form Other-filter",
+                        headercss : strHeaderCss,
+                    },
+                    {
+                        name : "Severance",
+                        title : "Severance",
+                        tooltip : "Severance: Includes payments when employment or member’s appointment ends or retiring allowance.",
+                        type : "number",
+                        width : "11%",
+                        cellRenderer : function(value, item) {
+                            return "<td>"
+                                    + renderDollarAmount(item["Severance"])
+                                    + "</td>";
+                        },
+                        headerTemplate : function() {
+                            return headerInnerHtml(this);
+                        },
+                        filterTemplate : function() {
+                            return _filterTemplate_Numeric(this);
+                        },
+                        filterValue : function() {
+                            return _getNumericFilterValue(this);
+                        },
+                        filtercss : "filter-form Severance-filter",
+                        headercss : strHeaderCss,
+                    },
+                    {
+                        name : "Attachments",
+                        title : "Attachments",
+                        tooltip : "Attachments: An employment contract (C) or severance agreement (S) for certain designated employees or members. If neither document is applicable, no attachment is posted.",
+                        type : "text",
+                        width : "9%",
+                        filtering : false,
+                        sorting : false,
+                        cellRenderer : function(value, item) {
+                            return "<td>"
+                                    + renderAttachments(
+                                            item["ContractAttachment"],
+                                            item["TerminationAttachment"])
+                                    + "</td>";
+                        },
+                        headerTemplate : function() {
+                            return headerInnerHtml(this);
+                        },
+                        headercss : strHeaderCss,
+                        filtercss : "filter-form",
+                    } ],
+            autoload : true,
+            controller : {
+                loadData : function(filter) {
                     _activateHeaderFilter(filter);
-                    return $.grep(data, function (data) {
-                        return (
-                            (!filter.PublicSectorBody || indexOfCaseInsensitive(data.PublicSectorBody, filter.PublicSectorBody) > -1) &&
-                            (!filter.Name || indexOfCaseInsensitive(data.Name, filter.Name) > -1) &&
-                            (!filter.Position || indexOfCaseInsensitive(data.Position, filter.Position) > -1) &&
-                            (!filter.Year || data.Year == filter.Year) &&
-                            (!filter.Compensation || _evaluateInequation(data.Compensation, filter.Compensation)) &&
-                            (!filter.Other || _evaluateInequation(data.Other, filter.Other)) &&
-                            (!filter.Severance || _evaluateInequation(data.Severance, filter.Severance)));
-                    });
+                    return $.grep( data, function(data) {
+                        return ((!filter.PublicSectorBody 
+                            || indexOfCaseInsensitive( 
+                                data.PublicSectorBody,
+                                filter.PublicSectorBody) > -1)
+                            && (!filter.Name || indexOfCaseInsensitive(
+                                data.Name, filter.Name) > -1)
+                            && (!filter.Position || indexOfCaseInsensitive(
+                                data.Position, filter.Position) > -1)
+                            && (!filter.Year || data.Year == filter.Year)
+                            && (!filter.Compensation || _evaluateInequation(
+                                data.Compensation, filter.Compensation))
+                            && (!filter.Other || _evaluateInequation(
+                                data.Other, filter.Other)) 
+                            && (!filter.Severance || _evaluateInequation(
+                                data.Severance, filter.Severance)));
+                        }
+                    );
                 },
             },
-            refresh: function() {
+            refresh : function() {
                 //prevent refresh from undoing custom filter code
                 this._callEventHandler(this.onRefreshing);
                 this.cancelEdit();
@@ -432,15 +456,28 @@ var abCompToolkit = (function() {
                 this._refreshSize();
                 this._callEventHandler(this.onRefreshed);
             },
-            width: "100%",
-            height: "auto",
-            pageSize: 10,
-            selecting: false,
-            filtering: true,
-            sorting: true,
-            paging: true,
-            
-        });
+            width : "100%",
+            height : "auto",
+            pageSize : 10,
+            selecting : false,
+            filtering : true,
+            sorting : true,
+            paging : true,
+
+        };
+        
+        // give users a change to alter the configuration of the grid before
+        // it is rendered.
+        if ( typeof (gridConfigCallback) == 'function' ) {
+            var newConfig = gridConfigCallback( gridConfig );
+            if ( newConfig != null ) {
+                // ensure even those that forget to return the config will have
+                // a working grid.
+                gridConfig = newConfig;
+            }
+        }
+        
+        theJsGrid = $("#grid").jsGrid( gridConfig );
 
         var $headerFilters = $('.filter-form');
         $headerFilters.each(function (index, item) {


### PR DESCRIPTION
This is a pull request that should satisfy the issue I opened (https://github.com/abgov/ab-compensation-transparency-toolkit/issues/7).

It should probably also include an example on the information page for the project so users know how to use this new callback functionality. Here's the type of example that could be provided:

<pre>
&lt;script type="text/javascript"&gt;
  var csv = "custom_named_disclosure.csv"; 
  var gridConfigCallback = function( gridConfig ) {

    // alter main grid options.
    gridConfig.pageSize = 15;
    
    // loop through the preconfigured fields to tweak their display
    $.each(gridConfig.fields, function(fieldIdx, field) {
      // hide Public Sector Body since you may only have one body
      if ( field.name == "PublicSectorBody" ) {
        field.visible = false;
      }
      // possibly tweak column widths...
      if ( field.name == "Year") {
        field.width = "5%";
      }
    })
    
    // and return new config...
    return gridConfig;
  }
&lt;/script&gt;
</pre>
